### PR TITLE
Added new Testcase: "_11_ProjectionToDTOFailsIfPropertyIsNotInDTO"

### DIFF
--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/CountryDTOWithoutPicture.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/CountryDTOWithoutPicture.cs
@@ -1,0 +1,17 @@
+﻿using GraphInheritenceTests.ComplexModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs
+{
+    public class CountryDTOWithoutPicture : IdBase
+    {
+        public string Name { get; set; }
+        public string IsoCode { get; set; }
+
+        public int? FlagPictureId { get; set; }
+    }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/GraphDetachedMappersTests.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/GraphDetachedMappersTests.cs
@@ -1,5 +1,6 @@
 using Detached.Mappers;
 using Detached.Mappers.EntityFramework;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs;
 using GraphInheritenceTests.ComplexModels;
 using GraphInheritenceTests.DeepModel;
 using GraphInheritenceTests.DTOs;
@@ -369,6 +370,28 @@ namespace GraphInheritenceTests
 
                 Assert.That(fanLoaded.Recommendations[0].RecommendedToId, Is.EqualTo(newCustomerId), "The Id is the same as itself or RecommendedById. The changed value got lost.");
                 Assert.That(fanLoaded.Recommendations[0].RecommendedToId, Is.Not.EqualTo(fanLoaded.Recommendations[0].RecommendedById));
+            }
+        }
+
+        [Test]
+        public void _11_ProjectionToDTOFailsIfPropertyIsNotInDTO()
+        {
+            var germany = new Country() { IsoCode = "DEU", Name = "Germany", FlagPicture = new Picture() { FileName = "schwarzRotGold.png" } };
+
+            using (ComplexDbContext dbContext = new ComplexDbContext())
+            {
+                dbContext.Countries.Add(germany);
+                dbContext.SaveChanges();
+            }
+
+            using (ComplexDbContext dbContext = new ComplexDbContext())
+            {
+                // System Null Reference Exception: 
+                // We Projecting a Entity on a DTO which has not all Properties on it.
+                // The type of the missing property doesnt matter (Tested with primitive, lists and complex types).
+                IQueryable<CountryDTOWithoutPicture> dtosQuery = dbContext.Project<Country, CountryDTOWithoutPicture>(dbContext.Countries);
+                var dto = dtosQuery.SingleOrDefault(item => item.IsoCode == "DEU");
+                Assert.That(dto, Is.Not.Null);
             }
         }
 


### PR DESCRIPTION
Hi Leonardo ;),

I really would like to thank you for working so hard for this package and helping @Robert-INdotNET and me to build our project. When installing the new package Version i spotted a small bug related to the projection method. 

This method fails (Null Reference Exception) when not all propertys of the entity are present in the DTO. For further investigations I included a new test case. 

Thank you very much and have a nice day ;).