### PR TITLE
Added Test 07_01

### DIFF
--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDbContext.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDbContext.cs
@@ -6,9 +6,11 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace GraphInheritenceTests
 {
@@ -25,7 +27,7 @@ namespace GraphInheritenceTests
         public DbSet<Recommendation> Recommendations { get; set; }
 
         public DbSet<TodoItem> TodoItems { get; set; }
-        public DbSet<SubTodoItem> SubTodoItems { get; set; }
+        public DbSet<ReusedLinkedItem> ReusedLinkedItems { get; set; }
         public DbSet<UploadedFile> UploadedFiles { get; set; }
 
         public DbSet<Student> Students { get; set; }
@@ -36,7 +38,7 @@ namespace GraphInheritenceTests
             optionsBuilder
                 .UseSqlite("Data Source=ComplexDB.db;")
                 .EnableSensitiveDataLogging()
-                .LogTo(Console.WriteLine)
+                .LogTo(message => Debug.WriteLine(message), LogLevel.Information)
                 .EnableDetailedErrors()
                 .UseDetached(options =>
                 {

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DeepModel/ReusedLinkedItem.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DeepModel/ReusedLinkedItem.cs
@@ -1,0 +1,17 @@
+﻿using Detached.Annotations;
+using GraphInheritenceTests.ComplexModels;
+using System.Collections.Generic;
+
+namespace GraphInheritenceTests.DeepModel
+{
+    /// <summary>
+    /// Will be used multiple times to reproduce a bug
+    /// </summary>
+    public class ReusedLinkedItem : IdBase
+    {
+        public string Title { get; set; }
+
+        [Composition]
+        public List<UploadedFile> UploadedFiles { get; set; }
+    }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DeepModel/TodoItem.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DeepModel/TodoItem.cs
@@ -15,6 +15,9 @@ namespace GraphInheritenceTests.DeepModel
         public bool IsDone { get; set; }
 
         [Composition]
-        public List<SubTodoItem> SubTodoItems { get; set; } = new List<SubTodoItem>();
+        public User User { get; set; }
+
+        [Composition]
+        public List<ReusedLinkedItem> ReusedLinkedItems { get; set; } = new();
     }
 }

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DeepModel/User.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DeepModel/User.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Detached.Annotations;
+using GraphInheritenceTests.ComplexModels;
+
+namespace GraphInheritenceTests.DeepModel
+{
+    public class User: IdBase
+    {
+        public string Name { get; set; }
+
+        [Composition]
+        public List<ReusedLinkedItem> ReusedLinkedItems { get; set; } = new();
+
+        [Aggregation]
+        public List<TodoItem> TodoItems { get; set; } = new();
+    }
+}


### PR DESCRIPTION
Hello Leonardo,
We ([Robert](https://github.com/Robert-INdotNET) and I) have been working diligently with detached mappers again and found a very tricky bug.
Detached mappers can't cope with two models, one nested and one not, that want to save the same model as a composition.
Then it accidentally makes a mistake and does not update it but does insert it.