### PR TITLE
Use Activator.CreateInstance() to create new list in CollectionTypeMapper

### DIFF
--- a/src/Detached.Mappers/TypeMappers/POCO/Collection/CollectionTypeMapper.cs
+++ b/src/Detached.Mappers/TypeMappers/POCO/Collection/CollectionTypeMapper.cs
@@ -24,7 +24,7 @@ namespace Detached.Mappers.TypeMappers.POCO.Collection
 
             if (source != null)
             {
-                result = (TTarget)(object)new List<TTargetItem>();
+                result = Activator.CreateInstance<TTarget>();
 
                 ITypeMapper<TSourceItem, TTargetItem> itemMapper = _itemMapper.Value;
 

--- a/test/Detached.Mappers.Tests/POCO/Complex/Collection/CollectionTests.cs
+++ b/test/Detached.Mappers.Tests/POCO/Complex/Collection/CollectionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 
 namespace Detached.Mappers.Tests.POCO.Complex.Collection
@@ -40,6 +41,20 @@ namespace Detached.Mappers.Tests.POCO.Complex.Collection
             Assert.Equal("Item 1", targetType.ComplexCollection[0].Name);
             Assert.Equal("Item 2", targetType.ComplexCollection[1].Name);
             Assert.Equal("Item 3", targetType.ComplexCollection[2].Name);
+        }
+
+        [Fact]
+        public void map_list_to_collection()
+        {
+            List<int> ints = new List<int> { 1, 2, 3, 4, 5 };
+
+            Collection<string> result = mapper.Map<List<int>, Collection<string>>(ints);
+
+            Assert.Equal("1", result[0]);
+            Assert.Equal("2", result[1]);
+            Assert.Equal("3", result[2]);
+            Assert.Equal("4", result[3]);
+            Assert.Equal("5", result[4]);
         }
 
         public class TargetType


### PR DESCRIPTION
Fixes issue #80 

Did some simple benchmarks in NET 6.0 to verify no loss in performance since reflection is use now instead of casting

```
/// Original code using cast (Collection to List)
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.22621
13th Gen Intel Core i7-13700K, 1 CPU, 24 logical and 16 physical cores
.NET Core SDK=7.0.203
  [Host]     : .NET Core 6.0.16 (CoreCLR 6.0.1623.17311, CoreFX 6.0.1623.17311), X64 RyuJIT
  DefaultJob : .NET Core 6.0.16 (CoreCLR 6.0.1623.17311, CoreFX 6.0.1623.17311), X64 RyuJIT


|    Method |     N |           Mean |        Error |      StdDev |    Gen 0 | Gen 1 | Gen 2 |   Allocated |
|---------- |------ |---------------:|-------------:|------------:|---------:|------:|------:|------------:|
| Benchmark |     1 |       234.8 ns |      1.43 ns |     1.34 ns |   0.0658 |     - |     - |     1.01 KB |
| Benchmark |   100 |    23,315.7 ns |     58.30 ns |    51.68 ns |   6.5613 |     - |     - |   100.78 KB |
| Benchmark | 10000 | 2,343,865.3 ns | 10,573.36 ns | 9,373.01 ns | 656.2500 |     - |     - | 10078.13 KB |

/// Activator.CreateInstance() (Collection to List)
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.22621
13th Gen Intel Core i7-13700K, 1 CPU, 24 logical and 16 physical cores
.NET Core SDK=7.0.203
  [Host]     : .NET Core 6.0.16 (CoreCLR 6.0.1623.17311, CoreFX 6.0.1623.17311), X64 RyuJIT
  DefaultJob : .NET Core 6.0.16 (CoreCLR 6.0.1623.17311, CoreFX 6.0.1623.17311), X64 RyuJIT


|    Method |     N |           Mean |        Error |       StdDev |    Gen 0 | Gen 1 | Gen 2 |   Allocated |
|---------- |------ |---------------:|-------------:|-------------:|---------:|------:|------:|------------:|
| Benchmark |     1 |       249.8 ns |      0.75 ns |      0.66 ns |   0.0658 |     - |     - |     1.01 KB |
| Benchmark |   100 |    24,227.3 ns |     72.74 ns |     64.48 ns |   6.5613 |     - |     - |   100.78 KB |
| Benchmark | 10000 | 2,342,963.2 ns | 12,526.80 ns | 11,717.58 ns | 656.2500 |     - |     - | 10078.13 KB |


```