### PR TITLE
Fix PR #83

### DIFF
--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDbContext.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDbContext.cs
@@ -8,9 +8,12 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
 using Microsoft.Extensions.Logging;
 using Detached.Mappers.EntityFramework.Contrib.SysTec.DeepModel;
 using Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance;
 
 namespace Detached.Mappers.EntityFramework.Contrib.SysTec
 {
@@ -35,6 +38,15 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
         public DbSet<Student> Students { get; set; }
         public DbSet<Course> Courses { get; set; }
 
+        public DbSet<EntityOne> EntityOnes { get; set; }
+        
+        public DbSet<EntityTwo> EntityTwos { get; set; }
+        
+        public DbSet<EntityThree> EntityThrees { get; set; }
+        
+        public DbSet<EntityFour> EntityFours { get; set; }
+        
+        
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder
@@ -59,6 +71,24 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
                         .Discriminator(o => o.OrganizationType)
                         .HasValue<GovernmentDTO>(nameof(Government))
                         .HasValue<SubGovernmentDTO>(nameof(SubGovernment));
+                    
+                    options.Type<BaseHead>()
+                        .Discriminator(o => o.Discriminator)
+                        .HasValue<EntityTwo>(nameof(EntityTwo))
+                        .HasValue<EntityThree>(nameof(EntityThree))
+                        .HasValue<EntityFour>(nameof(EntityFour));
+
+                    /*
+                     //Workaround for Test 15
+                    options.Type<BaseStationOneSecond>()
+                        .Discriminator(o => o.Discriminator)
+                        .HasValue<EntityThree>(nameof(EntityThree));
+
+                    options.Type<BaseStationOneFirst>()
+                        .Discriminator(o => o.Discriminator)
+                        .HasValue<EntityFour>(nameof(EntityFour))
+                        .HasValue<EntityTwo>(nameof(EntityTwo)); */
+
                 });
 
             //optionsBuilder.ConfigureWarnings(
@@ -98,13 +128,20 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
             {
                 entity.HasOne(s => s.Parent);
                 entity.HasMany(s => s.Children)
-                .WithOne()
-                .HasForeignKey(s => s.ParentId);
+                    .WithOne()
+                    .HasForeignKey(s => s.ParentId);
             });
 
             modelBuilder.Entity<Customer>()
                 .HasMany<Recommendation>(c => c.Recommendations)
                 .WithOne(r => r.RecommendedBy);
+
+            modelBuilder.Entity<BaseHead>()
+                .UseTphMappingStrategy()
+                .HasDiscriminator(b => b.Discriminator)
+                .HasValue<EntityTwo>(nameof(EntityTwo))
+                .HasValue<EntityThree>(nameof(EntityThree))
+                .HasValue<EntityFour>(nameof(EntityFour));
         }
 
         public override int SaveChanges()

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
@@ -870,5 +870,161 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
                 // See Test _14_1
             }
         }
+        
+        
+        [Test]
+        public void _15_1_AddEntityWithOwnedTypes_ShouldAlsoStoreOwnedTypeValues()
+        {
+            var newStudentDto = new StudentDTO()
+            {
+                Age = 16,
+                Name = "Chuck Norris",
+                Grades = new StudentGrades()
+                {
+                    English = "A+",
+                    ComputerScience = "C++",
+                    Math = "A+"
+                }
+            };
+
+            Student newStudentEntity;
+            
+            using (var dbContext = new ComplexDbContext())
+            {
+                newStudentEntity = dbContext.Map<Student>(newStudentDto);
+                
+                // Assert that the owned type is mapped correctly
+                Assert.That(newStudentEntity.Grades, Is.Not.Null);
+                Assert.That(newStudentEntity.Grades.English, Is.EqualTo("A+"));
+                Assert.That(newStudentEntity.Grades.ComputerScience, Is.EqualTo("C++"));
+                Assert.That(newStudentEntity.Grades.Math, Is.EqualTo("A+"));
+                
+                dbContext.SaveChanges();
+            }
+
+            using (var dbContext = new ComplexDbContext())
+            {
+                var studentFromDb = dbContext.Students.Single(s => s.Id == newStudentEntity.Id);
+                
+                // Assert that the owned type is stored in the db
+                Assert.That(studentFromDb.Grades, Is.Not.Null);
+                Assert.That(studentFromDb.Grades.English, Is.EqualTo("A+"));
+                Assert.That(studentFromDb.Grades.ComputerScience, Is.EqualTo("C++"));
+                Assert.That(studentFromDb.Grades.Math, Is.EqualTo("A+"));
+            }
+            
+            // Following Insert statement is executed:
+            // Executed DbCommand (0ms) [Parameters=[@p0='16', @p1='0', @p2='Chuck Norris' (Size = 12)], CommandType='Text', CommandTimeout='30']
+            // INSERT INTO "Students" ("Age", "ConcurrencyToken", "Name")
+            // VALUES (@p0, @p1, @p2);
+            // SELECT "Id"
+            // FROM "Students"
+            // WHERE changes() = 1 AND "rowid" = last_insert_rowid();
+            
+            // As you can see, none of the OwnedType columns are present in the statement
+            
+            // Test _15_2 shows the EF Core default behavior which stores the owned type values in the db
+            // Test _15_3 shows that the storing of owned types already works with Detached.Mappers when updating an entity
+        }
+
+        [Test]
+        public void _15_2_AddEntityWithOwnedTypes_WithPureEFCore_ShouldAlsoStoreOwnedTypeValues()
+        {
+            var newStudent = new Student()
+            {
+                Age = 16,
+                Name = "Chuck Norris",
+                Grades = new StudentGrades()
+                {
+                    English = "A+",
+                    ComputerScience = "C++",
+                    Math = "A+"
+                }
+            };
+
+            using (var dbContext = new ComplexDbContext())
+            {
+                dbContext.Add(newStudent);
+                dbContext.SaveChanges();
+                
+                Assert.That(newStudent.Grades, Is.Not.Null);
+                Assert.That(newStudent.Grades.English, Is.EqualTo("A+"));
+                Assert.That(newStudent.Grades.ComputerScience, Is.EqualTo("C++"));
+                Assert.That(newStudent.Grades.Math, Is.EqualTo("A+"));
+            }
+
+            using (var dbContext = new ComplexDbContext())
+            {
+                var newStudentFromDb = dbContext.Students.Single(s => s.Id == newStudent.Id);
+                Assert.That(newStudentFromDb.Grades, Is.Not.Null);
+                Assert.That(newStudentFromDb.Grades.English, Is.EqualTo("A+"));
+                Assert.That(newStudentFromDb.Grades.ComputerScience, Is.EqualTo("C++"));
+                Assert.That(newStudentFromDb.Grades.Math, Is.EqualTo("A+"));
+            }
+            
+            // Following Insert statement is executed:
+            // Executed DbCommand (0ms) [Parameters=[@p0='16', @p1='0', @p2='Chuck Norris' (Size = 12), @p3='C++' (Size = 3), @p4='A+' (Size = 2), @p5='A+' (Size = 2)], CommandType='Text', CommandTimeout='30']
+            // INSERT INTO "Students" ("Age", "ConcurrencyToken", "Name", "Grades_ComputerScience", "Grades_English", "Grades_Math")
+            // VALUES (@p0, @p1, @p2, @p3, @p4, @p5);
+            // SELECT "Id"
+            // FROM "Students"
+            // WHERE changes() = 1 AND "rowid" = last_insert_rowid();
+            
+        }
+
+        [Test]
+        public void _15_3_UpdateEntityWithOwnedTypes_AlsoUpdatesOwnedTypeValues()
+        {
+            var newStudentDto = new StudentDTO()
+            {
+                Age = 16,
+                Name = "Chuck Norris",
+                Grades = new StudentGrades()
+                {
+                    English = "A+",
+                    ComputerScience = "C++",
+                    Math = "A+"
+                }
+            };
+
+            Student newStudentEntity;
+            
+            using (var dbContext = new ComplexDbContext())
+            {
+                // Store student first
+                newStudentEntity = dbContext.Map<Student>(newStudentDto);
+                dbContext.SaveChanges();
+            }
+            
+            newStudentDto.Id = newStudentEntity.Id;
+            newStudentDto.ConcurrencyToken = newStudentEntity.ConcurrencyToken;
+
+            using (var dbContext = new ComplexDbContext())
+            {
+                // Now update the student
+                var updatedStudentEntity = dbContext.Map<Student>(newStudentDto);
+                dbContext.SaveChanges();
+                
+                Assert.That(updatedStudentEntity.Grades, Is.Not.Null);
+                Assert.That(updatedStudentEntity.Grades.English, Is.EqualTo("A+"));
+                Assert.That(updatedStudentEntity.Grades.ComputerScience, Is.EqualTo("C++"));
+                Assert.That(updatedStudentEntity.Grades.Math, Is.EqualTo("A+"));
+            }
+
+            using (var dbContext = new ComplexDbContext())
+            {
+                var updatedStudentFromDb = dbContext.Students.Single(s => s.Id == newStudentEntity.Id);
+                Assert.That(updatedStudentFromDb.Grades, Is.Not.Null);
+                Assert.That(updatedStudentFromDb.Grades.English, Is.EqualTo("A+"));
+                Assert.That(updatedStudentFromDb.Grades.ComputerScience, Is.EqualTo("C++"));
+                Assert.That(updatedStudentFromDb.Grades.Math, Is.EqualTo("A+"));
+            }
+            
+            // Following Update statement is executed:
+            // Executed DbCommand (0ms) [Parameters=[@p3='1', @p4='1', @p0='C++' (Size = 3), @p1='A+' (Size = 2), @p2='A+' (Size = 2)], CommandType='Text', CommandTimeout='30']
+            // UPDATE "Students" SET "Grades_ComputerScience" = @p0, "Grades_English" = @p1, "Grades_Math" = @p2
+            // WHERE "Id" = @p3 AND "ConcurrencyToken" = @p4;
+            // SELECT changes();
+        }
     }
 }

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
@@ -879,6 +879,8 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
             {
                 Age = 16,
                 Name = "Chuck Norris",
+                // This class is marked as owned with the [Owned] attribute
+                // StudentGrades also is a property of the corresponding Student class
                 Grades = new StudentGrades()
                 {
                     English = "A+",

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
@@ -10,6 +10,8 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance;
 using static System.Net.Mime.MediaTypeNames;
 
 namespace Detached.Mappers.EntityFramework.Contrib.SysTec
@@ -533,7 +535,7 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
             {
                 var mapped = dbContext.Map<Customer>(twoChangedCustomer);
 
-                Assert.That(mapped.Recommendations, Has.Count.EqualTo(1), "Entity reference has been duplicated, but shouldn't!");
+                Assert.That(mapped.Recommendations, Has.Count.EqualTo(1), "EntityinheritanceBaseOneDTO reference has been duplicated, but shouldn't!");
 
                 dbContext.SaveChanges();
             }
@@ -604,7 +606,7 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
             using (ComplexDbContext dbContext = new ComplexDbContext())
             {
                 // System Null Reference Exception: 
-                // We Projecting a Entity on a DTO which has not all Properties on it.
+                // We Projecting a EntityinheritanceBaseOneDTO on a DTO which has not all Properties on it.
                 // The type of the missing property doesnt matter (Tested with primitive, lists and complex types).
                 IQueryable<CountryDTOWithoutPicture> dtosQuery = dbContext.Project<Country, CountryDTOWithoutPicture>(dbContext.Countries);
                 var dto = dtosQuery.SingleOrDefault(item => item.IsoCode == "DEU");
@@ -871,7 +873,6 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
             }
         }
         
-        
         [Test]
         public void _15_1_AddEntityWithOwnedTypes_ShouldAlsoStoreOwnedTypeValues()
         {
@@ -1027,6 +1028,40 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
             // UPDATE "Students" SET "Grades_ComputerScience" = @p0, "Grades_English" = @p1, "Grades_Math" = @p2
             // WHERE "Id" = @p3 AND "ConcurrencyToken" = @p4;
             // SELECT changes();
+        }
+
+
+        [Test]
+
+        public void _16_TryBaseListToLinkWithEntity_WithMap_ShouldNotThrow()
+        {
+            var dto = new EntityOneDTO()
+            {
+                BaseHeads = new()
+                {
+                    new EntityTwoDTO()
+                    {
+                        Discriminator = nameof(EntityTwo)
+                    },
+                    new EntityFourDTO()
+                    {
+                        Discriminator = nameof(EntityFour),
+                        BaseStationOneSeconds = new()
+                        {
+                            new EntityThreeDTO()
+                            {
+                                Discriminator = nameof(EntityThree)
+                            }
+                        }
+                    }
+                }
+            };
+            
+            using (var dbContext = new ComplexDbContext())
+            {
+                var mappedEntityOne = dbContext.Map<EntityOne>(dto);
+                dbContext.SaveChanges();
+            }
         }
     }
 }

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
@@ -881,7 +881,7 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
                 Name = "Chuck Norris",
                 // This class is marked as owned with the [Owned] attribute
                 // StudentGrades also is a property of the corresponding Student class
-                Grades = new StudentGrades()
+                Grades = new StudentGradesDTO()
                 {
                     English = "A+",
                     ComputerScience = "C++",
@@ -981,7 +981,7 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
             {
                 Age = 16,
                 Name = "Chuck Norris",
-                Grades = new StudentGrades()
+                Grades = new StudentGradesDTO()
                 {
                     English = "A+",
                     ComputerScience = "C++",

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/ClassDiagram1.cd
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/ClassDiagram1.cd
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ClassDiagram MajorVersion="1" MinorVersion="1">
+  <Class Name="Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel.BaseHead" Collapsed="true">
+    <Position X="6.5" Y="1.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>ComplexModels\inheritance\BaseModel\BaseHead.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel.BaseStationOneFirst" Collapsed="true">
+    <Position X="7.5" Y="3" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>ComplexModels\inheritance\BaseModel\BaseStationOneFirst.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel.BaseStationOneFirstOne" Collapsed="true">
+    <Position X="6.5" Y="4.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>ComplexModels\inheritance\BaseModel\BaseStationOneFirstOne.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel.BaseStationOneSecond" Collapsed="true">
+    <Position X="4.25" Y="3" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>ComplexModels\inheritance\BaseModel\BaseStationOneSecond.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel.BaseStationOneSecondOne" Collapsed="true">
+    <Position X="4.25" Y="4.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>ComplexModels\inheritance\BaseModel\BaseStationOneSecondOne.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.EntityFour" Collapsed="true">
+    <Position X="8.75" Y="4.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>ComplexModels\inheritance\EntityFour.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.EntityOne" Collapsed="true">
+    <Position X="11.25" Y="1.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAA=</HashCode>
+      <FileName>ComplexModels\inheritance\EntityOne.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.EntityThree" Collapsed="true">
+    <Position X="4.25" Y="5.75" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>ComplexModels\inheritance\EntityThree.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.EntityTwo" Collapsed="true">
+    <Position X="6.5" Y="5.75" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>ComplexModels\inheritance\EntityTwo.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Font Name="Segoe UI" Size="9" />
+</ClassDiagram>

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Student.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Student.cs
@@ -9,6 +9,7 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels
 
         public int Age { get; set; }
         
+        [Composition]
         public StudentGrades Grades { get; set; }
 
         [Aggregation]

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Student.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Student.cs
@@ -8,6 +8,8 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels
         public string Name { get; set; }
 
         public int Age { get; set; }
+        
+        public StudentGrades Grades { get; set; }
 
         [Aggregation]
         public List<Course> Courses { get; set; }

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/StudentGrades.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/StudentGrades.cs
@@ -1,3 +1,4 @@
+using Detached.Annotations;
 using Microsoft.EntityFrameworkCore;
 
 namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels;

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/StudentGrades.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/StudentGrades.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels;
+
+[Owned]
+public class StudentGrades
+{
+    public string English { get; set; }
+
+    public string Math { get; set; }
+
+    public string ComputerScience { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/BaseModel/BaseHead.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/BaseModel/BaseHead.cs
@@ -1,0 +1,6 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+public abstract class BaseHead : IdBase
+{
+  public string Discriminator { get; set; }  
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/BaseModel/BaseStationOneFirst.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/BaseModel/BaseStationOneFirst.cs
@@ -1,0 +1,6 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+public abstract class BaseStationOneFirst : BaseHead
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/BaseModel/BaseStationOneFirstOne.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/BaseModel/BaseStationOneFirstOne.cs
@@ -1,0 +1,6 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+public abstract class BaseStationOneFirstOne : BaseStationOneFirst
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/BaseModel/BaseStationOneSecond.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/BaseModel/BaseStationOneSecond.cs
@@ -1,0 +1,6 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+public abstract class BaseStationOneSecond : BaseHead
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/BaseModel/BaseStationOneSecondOne.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/BaseModel/BaseStationOneSecondOne.cs
@@ -1,0 +1,6 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+public abstract class BaseStationOneSecondOne : BaseStationOneSecond
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/EntityFour.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/EntityFour.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Detached.Annotations;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance;
+
+public class EntityFour : BaseStationOneFirst
+{
+    [Composition]
+    public List<BaseStationOneSecond> BaseStationOneSeconds { get; set; } = new();
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/EntityOne.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/EntityOne.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Detached.Annotations;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance;
+
+public class EntityOne : IdBase
+{
+    [Composition]
+    public List<BaseHead> BaseHeads { get; set; } = new();
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/EntityThree.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/EntityThree.cs
@@ -1,0 +1,8 @@
+﻿using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance;
+
+public class EntityThree : BaseStationOneSecondOne
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/EntityTwo.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/inheritance/EntityTwo.cs
@@ -1,0 +1,8 @@
+﻿using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance;
+
+public class EntityTwo : BaseStationOneFirstOne
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/StudentDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/StudentDTO.cs
@@ -13,6 +13,6 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs
         
         public int Age { get; set; }
         
-        public StudentGrades Grades { get; set; }
+        public StudentGradesDTO Grades { get; set; }
     }
 }

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/StudentDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/StudentDTO.cs
@@ -3,12 +3,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels;
 
 namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs
 {
     public class StudentDTO : IdBaseDTO
     {
         public string Name { get; set; }
+        
         public int Age { get; set; }
+        
+        public StudentGrades Grades { get; set; }
     }
 }

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/StudentGradesDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/StudentGradesDTO.cs
@@ -1,0 +1,10 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs;
+
+public class StudentGradesDTO
+{
+    public string English { get; set; }
+
+    public string Math { get; set; }
+
+    public string ComputerScience { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/BaseModel/BaseHeadDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/BaseModel/BaseHeadDTO.cs
@@ -1,0 +1,6 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance.BaseModel;
+
+public abstract class BaseHeadDTO : IdBaseDTO
+{
+  public string Discriminator { get; set; }  
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/BaseModel/BaseStationOneFirstDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/BaseModel/BaseStationOneFirstDTO.cs
@@ -1,0 +1,8 @@
+﻿using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance.BaseModel;
+
+public abstract class BaseStationOneFirstDTO : BaseHeadDTO
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/BaseModel/BaseStationOneFirstOneDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/BaseModel/BaseStationOneFirstOneDTO.cs
@@ -1,0 +1,8 @@
+﻿using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance.BaseModel;
+
+public abstract class BaseStationOneFirstOneDTO : BaseStationOneFirstDTO
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/BaseModel/BaseStationOneSecondDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/BaseModel/BaseStationOneSecondDTO.cs
@@ -1,0 +1,8 @@
+﻿using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance.BaseModel;
+
+public abstract class BaseStationOneSecondDTO : BaseHeadDTO
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/BaseModel/BaseStationOneSecondOneDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/BaseModel/BaseStationOneSecondOneDTO.cs
@@ -1,0 +1,8 @@
+﻿using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance.BaseModel;
+
+public abstract class BaseStationOneSecondOneDTO : BaseStationOneSecondDTO
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/EntityFourDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/EntityFourDTO.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance;
+
+public class EntityFourDTO : BaseStationOneFirstDTO
+{
+    public List<BaseStationOneSecondDTO> BaseStationOneSeconds { get; set; } = new();
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/EntityOneDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/EntityOneDTO.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance;
+
+public class EntityOneDTO : IdBaseDTO
+{
+    public List<BaseHeadDTO> BaseHeads { get; set; } = new();
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/EntityThreeDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/EntityThreeDTO.cs
@@ -1,0 +1,9 @@
+﻿using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance;
+
+public class EntityThreeDTO : BaseStationOneSecondOneDTO
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/EntityTwoDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/inheritance/EntityTwoDTO.cs
@@ -1,0 +1,9 @@
+﻿using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance.BaseModel;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance;
+
+public class EntityTwoDTO : BaseStationOneFirstOneDTO
+{
+    
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/Detached.Mappers.EntityFramework.Contrib.SysTec.csproj
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/Detached.Mappers.EntityFramework.Contrib.SysTec.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Detached.Mappers.EntityFramework/Conventions/EFConventions.cs
+++ b/src/Detached.Mappers.EntityFramework/Conventions/EFConventions.cs
@@ -40,7 +40,7 @@ namespace Detached.Mappers.EntityFramework.Conventions
                 }
 
                 IProperty discriminator = entityType.FindDiscriminatorProperty();
-                if (discriminator != null && entityType.BaseType == null)
+                if (discriminator != null && (entityType.BaseType == null ||entityType.IsAbstract()))
                 {
                     typeOptions.SetDiscriminatorName(discriminator.Name);
 

--- a/src/Detached.Mappers.EntityFramework/Conventions/EFConventions.cs
+++ b/src/Detached.Mappers.EntityFramework/Conventions/EFConventions.cs
@@ -18,7 +18,7 @@ namespace Detached.Mappers.EntityFramework.Conventions
         {
             IEntityType entityType = _model.FindEntityType(typeOptions.ClrType);
 
-            if (entityType != null && !entityType.IsOwned())
+            if (entityType != null)
             {
                 typeOptions.Entity(true);
             }

--- a/src/Detached.Mappers/TypeMappers/Entity/Complex/ComposedEntityTypeMapper.cs
+++ b/src/Detached.Mappers/TypeMappers/Entity/Complex/ComposedEntityTypeMapper.cs
@@ -54,7 +54,9 @@ namespace Detached.Mappers.TypeMappers.Entity.Complex
                 else
                 {
                     TKey targetKey = _getTargetKey(target, context);
-                    if (Equals(sourceKey, targetKey))
+                    bool isOwnedEntityWithoutKey = targetKey is NoKey && sourceKey is NoKey;
+                    //Problem with Owned Entities: sourcekey and targetKey are both NoKey with the same properties, but Equals does not recognize them as equal values
+                    if (Equals(sourceKey, targetKey) || isOwnedEntityWithoutKey)
                     {
                         context.PushResult(entityRef, target);
                         _mapNoKeyMembers(source, target, context);

--- a/test/Detached.Mappers.EntityFramework.Tests/MapOwnedTests.cs
+++ b/test/Detached.Mappers.EntityFramework.Tests/MapOwnedTests.cs
@@ -1,19 +1,22 @@
-﻿using Detached.Mappers.EntityFramework.Tests.Model;
+﻿using System.Data.Entity;
+using System.Threading.Tasks;
+using Detached.Mappers.EntityFramework.Tests.Model;
 using Detached.Mappers.EntityFramework.Tests.Model.DTOs;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Detached.Mappers.EntityFramework.Tests
-{
-    public class MapOwnedTests
-    {
-        [Fact]
-        public async Task map_owned()
-        {
-            DefaultTestDbContext db = await DefaultTestDbContext.CreateAsync();
+namespace Detached.Mappers.EntityFramework.Tests;
 
-            Invoice invoice = await db.MapAsync<Invoice>(new InvoiceDTO
+public class MapOwnedTests
+{
+    [Fact]
+    public async Task map_owned()
+    {
+        Invoice invoice;
+        using (var db = await DefaultTestDbContext.CreateAsync())
+        {
+            invoice = await db.MapAsync<Invoice>(new InvoiceDTO
             {
                 ShippingAddress = new ShippingAddressDTO
                 {
@@ -24,8 +27,11 @@ namespace Detached.Mappers.EntityFramework.Tests
             });
 
             await db.SaveChangesAsync();
+        }
 
-            Invoice persisted = db.Invoices.Where(i => i.Id == invoice.Id).FirstOrDefault();
+        using (var db = await DefaultTestDbContext.CreateAsync())
+        {
+            Invoice persisted = db.Invoices.FirstOrDefault(i => i.Id == invoice.Id);
             Assert.NotNull(persisted);
             Assert.NotNull(persisted.ShippingAddress);
             Assert.Equal("Zeballos St. 2135", persisted.ShippingAddress.Line1);

--- a/test/Detached.Mappers.EntityFramework.Tests/Model/Invoice.cs
+++ b/test/Detached.Mappers.EntityFramework.Tests/Model/Invoice.cs
@@ -13,6 +13,7 @@ namespace Detached.Mappers.EntityFramework.Tests.Model
         [Composition]
         public virtual List<InvoiceRow> Rows { get; set; }
 
+        [Composition]
         public virtual ShippingAddress ShippingAddress { get; set; }
     }
 }

--- a/test/Detached.Mappers.EntityFramework.Tests/Model/ShippingAddress.cs
+++ b/test/Detached.Mappers.EntityFramework.Tests/Model/ShippingAddress.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
 
 namespace Detached.Mappers.EntityFramework.Tests.Model
 {


### PR DESCRIPTION
Owned is now treated as a normal entity.

During the update I had the following problem in the `ComposedEntityTypeMapper.cs`: 
Although sourceKey and targetKey had the same object with the same values NoKey it didn't consider them as the same. I have fixed this by: 
```csharp
...
TKey targetKey = _getTargetKey(target, context);
bool isOwnedEntityWithoutKey = targetKey is NoKey && sourceKey is NoKey;
 if (Equals(sourceKey, targetKey) || isOwnedEntityWithoutKey)
...
```