### PR TITLE
Owned Entities behave in a manner modified to Owned Attributes And Upgrade to .Net 6.0

### DIFF
--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDbContext.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDbContext.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug17;
 using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance;
 using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
 using Microsoft.Extensions.Logging;
@@ -45,6 +46,14 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
         public DbSet<EntityThree> EntityThrees { get; set; }
         
         public DbSet<EntityFour> EntityFours { get; set; }
+        
+        public DbSet<Angebot> Angebote { get; set; }
+        
+        public DbSet<PositionBase> Positionen { get; set; }
+        
+        public DbSet<ArtikelPosition> ArtikelPositionen { get; set; }
+        
+        public DbSet<UeberschriftPosition> UeberschriftPositionen { get; set; }
         
         
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -143,6 +152,12 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
                 .HasValue<EntityTwo>(nameof(EntityTwo))
                 .HasValue<EntityThree>(nameof(EntityThree))
                 .HasValue<EntityFour>(nameof(EntityFour));
+            
+            modelBuilder.Entity<PositionBase>()
+                .UseTphMappingStrategy()
+                .HasDiscriminator(p => p.Positionsart)
+                .HasValue<ArtikelPosition>(nameof(ArtikelPosition))
+                .HasValue<UeberschriftPosition>(nameof(UeberschriftPosition));
         }
 
         public override int SaveChanges()

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDbContext.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDbContext.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug17;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug18;
 using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance;
 using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance.BaseModel;
 using Microsoft.Extensions.Logging;
@@ -55,7 +56,9 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
         
         public DbSet<UeberschriftPosition> UeberschriftPositionen { get; set; }
         
+        public DbSet<Artikel> Artikel { get; set; }
         
+        public DbSet<Zubehoer> Zubehoer { get; set; }
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder
@@ -158,6 +161,12 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
                 .HasDiscriminator(p => p.Positionsart)
                 .HasValue<ArtikelPosition>(nameof(ArtikelPosition))
                 .HasValue<UeberschriftPosition>(nameof(UeberschriftPosition));
+            
+            modelBuilder.Entity<ArtikelBase>()
+                .UseTphMappingStrategy()
+                .HasDiscriminator(a => a.Discriminator)
+                .HasValue<Artikel>(nameof(Artikel))
+                .HasValue<Zubehoer>(nameof(Zubehoer));
         }
 
         public override int SaveChanges()

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
@@ -11,8 +11,10 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug17;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug18;
 using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.inheritance;
 using Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.Bug17;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.Bug18;
 using Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.inheritance;
 using static System.Net.Mime.MediaTypeNames;
 
@@ -884,7 +886,7 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
                 Name = "Chuck Norris",
                 // This class is marked as owned with the [Owned] attribute
                 // StudentGrades also is a property of the corresponding Student class
-                Grades = new StudentGradesDTO()
+                Grades = new StudentGrades()
                 {
                     English = "A+",
                     ComputerScience = "C++",
@@ -984,7 +986,7 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
             {
                 Age = 16,
                 Name = "Chuck Norris",
-                Grades = new StudentGradesDTO()
+                Grades = new StudentGrades()
                 {
                     English = "A+",
                     ComputerScience = "C++",
@@ -1119,6 +1121,34 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
             {
                 var mappedEntityOne = dbContext.Map<Angebot>(dtoAfterSave);
                 dbContext.SaveChanges();
+            }
+        }  
+        [Test]
+        public void _18_TryItemsAreMovedFromOneListToAnother_WithMap_ShouldNotThrow()
+        {
+            var dto = new ArtikelDTO()
+            {
+                OwnedOne = new OwnedOneDTO()
+                {
+                    DateTime = DateTime.Now,
+                },
+                OwnedTwo = new OwnedTwoDTO()
+                {
+                    Bool = true
+                }
+            };
+            
+            Artikel dbUpdated;
+            using (var dbContext = new ComplexDbContext())
+            { 
+                var mappedEntityOne = dbContext.Map<Artikel>(dto);
+                dbContext.SaveChanges();
+                dbUpdated = dbContext.Artikel.First();
+            }
+
+            using (var dbContext = new ComplexDbContext())
+            {
+                dbUpdated = dbContext.Artikel.First();
             }
         }    
     }

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexDeepModelBugReproTests.cs
@@ -1124,7 +1124,7 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
             }
         }  
         [Test]
-        public void _18_TryItemsAreMovedFromOneListToAnother_WithMap_ShouldNotThrow()
+        public void _18_TryToUseOwnedEntitiesInInheritance_WithMap_ShouldNotThrow()
         {
             var dto = new ArtikelDTO()
             {
@@ -1149,6 +1149,10 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec
             using (var dbContext = new ComplexDbContext())
             {
                 dbUpdated = dbContext.Artikel.First();
+                Assert.That(dbUpdated.OwnedOne, Is.Not.Null);
+                Assert.That(dbUpdated.OwnedTwo, Is.Not.Null);
+                Assert.That(dbUpdated.OwnedOne.DateTime, Is.Not.Null);
+                Assert.That(dbUpdated.OwnedTwo.Bool, Is.True);
             }
         }    
     }

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug17/Angebot.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug17/Angebot.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using Detached.Annotations;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug17;
+
+public class Angebot : IdBase
+{
+    [Composition]
+    public List<PositionBase> Positionen { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug17/ArtikelPosition.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug17/ArtikelPosition.cs
@@ -1,0 +1,9 @@
+﻿using Detached.Annotations;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug17;
+
+public class ArtikelPosition : PositionBase
+{
+    [Aggregation]
+    public UeberschriftPosition ParentPosition { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug17/PositionBase.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug17/PositionBase.cs
@@ -1,0 +1,6 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug17;
+
+public abstract class PositionBase : IdBase
+{
+    public string Positionsart { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug17/UeberschriftPosition.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug17/UeberschriftPosition.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using Detached.Annotations;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug17;
+
+public class UeberschriftPosition : PositionBase
+{
+    [Composition]
+    public List<PositionBase> Positionen { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug18/Artikel.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug18/Artikel.cs
@@ -1,0 +1,8 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug18;
+
+public class Artikel : ArtikelBase
+{
+    public OwnedOne OwnedOne { get; set; }
+    
+    public OwnedTwo OwnedTwo { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug18/ArtikelBase.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug18/ArtikelBase.cs
@@ -1,0 +1,6 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug18;
+
+public abstract class ArtikelBase : IdBase
+{
+    public string Discriminator { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug18/OwnedOne.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug18/OwnedOne.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug18;
+
+[Owned]
+public class OwnedOne
+{
+    public DateTime DateTime { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug18/OwnedTwo.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug18/OwnedTwo.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug18;
+
+[Owned]
+public class OwnedTwo
+{
+    public bool Bool { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug18/Zubehoer.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Bug18/Zubehoer.cs
@@ -1,0 +1,8 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels.Bug18;
+
+public class Zubehoer : ArtikelBase
+{
+    public OwnedOne OwnedOne { get; set; }
+    
+    public OwnedTwo OwnedTwo { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Student.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/ComplexModels/Student.cs
@@ -9,7 +9,6 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels
 
         public int Age { get; set; }
         
-        [Composition]
         public StudentGrades Grades { get; set; }
 
         [Aggregation]

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug17/AngebotDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug17/AngebotDTO.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.Bug17;
+
+public class AngebotDTO : IdBaseDTO
+{
+    public List<PositionBaseDTO> Positionen { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug17/ArtikelPositionDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug17/ArtikelPositionDTO.cs
@@ -1,0 +1,9 @@
+﻿using Detached.Annotations;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.Bug17;
+
+public class ArtikelPositionDTO : PositionBaseDTO
+{
+    [Aggregation]
+    public UeberschriftPositionDTO ParentPosition { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug17/PositionBaseDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug17/PositionBaseDTO.cs
@@ -1,0 +1,8 @@
+﻿using Detached.Mappers.EntityFramework.Contrib.SysTec.ComplexModels;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.Bug17;
+
+public abstract class PositionBaseDTO : IdBaseDTO
+{
+    public string Positionsart { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug17/UeberschriftPositionDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug17/UeberschriftPositionDTO.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using Detached.Annotations;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.Bug17;
+
+public class UeberschriftPositionDTO : PositionBaseDTO
+{
+    [Composition]
+    public List<PositionBaseDTO> Positionen { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug18/ArtikelBaseDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug18/ArtikelBaseDTO.cs
@@ -1,0 +1,6 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.Bug18;
+
+public abstract class ArtikelBaseDTO : IdBaseDTO
+{
+    public string Discriminator { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug18/ArtikelDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug18/ArtikelDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.Bug18;
+
+public class ArtikelDTO : ArtikelBaseDTO
+{
+    public OwnedOneDTO OwnedOne { get; set; }
+    
+    public OwnedTwoDTO OwnedTwo { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug18/OwnedOneDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug18/OwnedOneDTO.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.Bug18;
+
+public class OwnedOneDTO
+{
+    public DateTime DateTime { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug18/OwnedTwoDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug18/OwnedTwoDTO.cs
@@ -1,0 +1,6 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.Bug18;
+
+public class OwnedTwoDTO
+{
+    public bool Bool { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug18/ZubehoerDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/Bug18/ZubehoerDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs.Bug18;
+
+public class ZubehoerDTO : ArtikelBaseDTO
+{
+    public OwnedOneDTO OwnedOne { get; set; }
+    
+    public OwnedTwoDTO OwnedTwo { get; set; }
+}

--- a/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/StudentDTO.cs
+++ b/contrib/Detached.Mappers.EntityFramework.Contrib.SysTec/DTOs/StudentDTO.cs
@@ -13,6 +13,6 @@ namespace Detached.Mappers.EntityFramework.Contrib.SysTec.DTOs
         
         public int Age { get; set; }
         
-        public StudentGradesDTO Grades { get; set; }
+        public StudentGrades Grades { get; set; }
     }
 }

--- a/src/Detached.Mappers.EntityFramework/Detached.Mappers.EntityFramework.csproj
+++ b/src/Detached.Mappers.EntityFramework/Detached.Mappers.EntityFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>7.1.0</Version>
+    <Version>7.1.2</Version>
     <Authors>Leonardo Porro</Authors>
     <Company />
     <Product>Detached</Product>
@@ -13,6 +13,7 @@
     <NeutralLanguage />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIcon>logo.png</PackageIcon>
+    <PackageId>Detached.Mappers.EntityFramework.Systec</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Detached.Mappers/Annotations/OwnedAnnotationHandler.cs
+++ b/src/Detached.Mappers/Annotations/OwnedAnnotationHandler.cs
@@ -1,0 +1,44 @@
+﻿using Detached.Mappers.TypePairs;
+using Detached.Mappers.Types;
+using Detached.Mappers.Types.Class;
+using Detached.Mappers.Types.Class.Builder;
+using Microsoft.EntityFrameworkCore;
+
+namespace Detached.Mappers.Annotations
+{
+    public class OwnedAnnotationHandler : AnnotationHandler<OwnedAttribute>
+    {
+        public override void Apply(OwnedAttribute annotation, MapperOptions mapperOptions, ClassType typeOptions,
+            ClassTypeMember memberOptions)
+        {
+            typeOptions.Owned(true);
+        }
+    }
+}
+
+namespace Detached.Mappers
+{
+    public static class OwnedAnnotationHandlerExtensions
+    {
+        public const string KEY = "DETACHED_OWNED";
+
+        public static bool IsOwned(this IType type)
+        {
+            return type.Annotations.ContainsKey(KEY);
+        }
+
+        public static void Owned(this IType type, bool value = true)
+        {
+            if (value)
+                type.Annotations[KEY] = true;
+            else
+                type.Annotations.Remove(KEY);
+        }
+
+        public static ClassTypeBuilder<TType> Owned<TType>(this ClassTypeBuilder<TType> type, bool value = true)
+        {
+            type.TypeOptions.Owned(value);
+            return type;
+        }
+    }
+}

--- a/src/Detached.Mappers/Detached.Mappers.csproj
+++ b/src/Detached.Mappers/Detached.Mappers.csproj
@@ -1,42 +1,44 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>7.1.0</Version>
-    <Authors>Leonardo Porro</Authors>
-    <Company />
-    <Product>Detached</Product>
-    <Description>A general purpose object-oriented mapper.</Description>
-    <Copyright>2017</Copyright>
-    <PackageProjectUrl>https://github.com/leonardoporro/Detached</PackageProjectUrl>
-    <NeutralLanguage />
-    <PackageLicenseExpression>(LGPL-2.0-only WITH FLTK-exception OR Apache-2.0+)</PackageLicenseExpression>
-    <PackageIcon>logo.png</PackageIcon>
-    <UserSecretsId>fce27d9c-812b-4f23-bd8f-9a8ee994297d</UserSecretsId>
-  </PropertyGroup>
+    <PropertyGroup>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+        <Version>7.1.0</Version>
+        <Authors>Leonardo Porro</Authors>
+        <Company />
+        <Product>Detached</Product>
+        <Description>A general purpose object-oriented mapper.</Description>
+        <Copyright>2017</Copyright>
+        <PackageProjectUrl>https://github.com/leonardoporro/Detached</PackageProjectUrl>
+        <NeutralLanguage />
+        <PackageLicenseExpression>(LGPL-2.0-only WITH FLTK-exception OR Apache-2.0+)</PackageLicenseExpression>
+        <PackageIcon>logo.png</PackageIcon>
+        <UserSecretsId>fce27d9c-812b-4f23-bd8f-9a8ee994297d</UserSecretsId>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <LangVersion>11</LangVersion>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Detached.RuntimeTypes" Version="6.0.0" />
-    <PackageReference Include="Detached.PatchTypes" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Detached.RuntimeTypes" Version="6.0.0" />
+        <PackageReference Include="Detached.PatchTypes" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="7.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+        <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+        <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Detached.Annotations\Detached.Annotations.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Detached.Annotations\Detached.Annotations.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\logo.png">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\logo.png">
+            <Pack>True</Pack>
+            <PackagePath></PackagePath>
+        </None>
+    </ItemGroup>
 
 </Project>

--- a/src/Detached.Mappers/Detached.Mappers.csproj
+++ b/src/Detached.Mappers/Detached.Mappers.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <Version>7.1.0</Version>
+        <Version>7.1.2</Version>
         <Authors>Leonardo Porro</Authors>
         <Company />
         <Product>Detached</Product>
@@ -16,6 +16,7 @@
         <UserSecretsId>fce27d9c-812b-4f23-bd8f-9a8ee994297d</UserSecretsId>
         <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <LangVersion>11</LangVersion>
+        <PackageId>Detached.Mappers.Systec</PackageId>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Detached.Mappers/MapperOptions.cs
+++ b/src/Detached.Mappers/MapperOptions.cs
@@ -22,6 +22,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace Detached.Mappers
 {
@@ -95,7 +96,8 @@ namespace Detached.Mappers
                 { typeof(NotMappedAttribute), new NotMappedAnnotationHandler() },
                 { typeof(NotAttachedAttribute), new NotAttachedAnnotationHandler() },
                 { typeof(ParentAttribute), new ParentAnnotationHandler() },
-                { typeof(AbstractAttribute), new AbstractAnnotationHandler() }
+                { typeof(AbstractAttribute), new AbstractAnnotationHandler() },
+                { typeof(OwnedAttribute), new OwnedAnnotationHandler()}
             };
 
             PropertyNameConventions = new List<IPropertyNameConvention>();

--- a/src/Detached.Mappers/TypeMappers/Entity/Complex/EntityTypeMapperFactory.cs
+++ b/src/Detached.Mappers/TypeMappers/Entity/Complex/EntityTypeMapperFactory.cs
@@ -53,6 +53,21 @@ namespace Detached.Mappers.TypeMappers.Entity.Complex
                             mapNoKeyMembers.Compile()
                        });
             }
+            else if (typePair.TargetType.IsOwned() || typePair.SourceType.IsOwned())
+            {
+                Type mapperType = typeof(OwnedEntityTypeMapper<,,>).MakeGenericType(typePair.SourceType.ClrType, typePair.TargetType.ClrType, keyType);
+                LambdaExpression mapKeyMembers = builder.BuildMapMembersExpression(typePair, (s, t) => t.IsKey());
+                LambdaExpression mapNoKeyMembers = builder.BuildMapMembersExpression(typePair, (s, t) => !t.IsKey());
+
+                return (ITypeMapper)Activator.CreateInstance(mapperType,
+                    new object[] {
+                        construct.Compile(),
+                        getSourceKeyExpr.Compile(),
+                        getTargetKeyExpr.Compile(),
+                        mapKeyMembers.Compile(),
+                        mapNoKeyMembers.Compile()
+                    });
+            }
             else
             {
                 Type mapperType = typeof(AggregatedEntityTypeMapper<,,>).MakeGenericType(typePair.SourceType.ClrType, typePair.TargetType.ClrType, keyType);

--- a/src/Detached.Mappers/Types/Class/ClassTypeFactory.cs
+++ b/src/Detached.Mappers/Types/Class/ClassTypeFactory.cs
@@ -74,7 +74,7 @@ namespace Detached.Mappers.Types.Class
             // apply conventions.
             foreach (ITypeConvention convention in options.TypeConventions)
             {
-                convention.Apply(options, classType);
+                 convention.Apply(options, classType);
             }
 
             // manual configuration is applied after all of this.

--- a/test/Detached.Mappers.EntityFramework.Tests/Model/Invoice.cs
+++ b/test/Detached.Mappers.EntityFramework.Tests/Model/Invoice.cs
@@ -13,7 +13,6 @@ namespace Detached.Mappers.EntityFramework.Tests.Model
         [Composition]
         public virtual List<InvoiceRow> Rows { get; set; }
 
-        [Composition]
         public virtual ShippingAddress ShippingAddress { get; set; }
     }
 }


### PR DESCRIPTION
I removed the code in Composed Type Mapper and added an AnnotationHandler for Owned Entities instead. 
It also makes sense to move away from .netStandard and upgrade the project to .Net 6.0 since .netStandard is deprecated.
.Net 6.0 is still compatible to other operating systems like MacOS or Linux.
@leonardoporro I ask for quick feedback and fast release on Nuget.