### PR TITLE
chore: change target framework to multi-target

### DIFF
--- a/src/Detached.Annotations/Detached.Annotations.csproj
+++ b/src/Detached.Annotations/Detached.Annotations.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-	<Version>8.0.0-preview.1</Version>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+	<Version>8.0.0-preview.2</Version>
     <Authors>Leonardo Porro</Authors>
     <Company />
     <Product>Detached</Product>

--- a/src/Detached.Mappers.EntityFramework/Detached.Mappers.EntityFramework.csproj
+++ b/src/Detached.Mappers.EntityFramework/Detached.Mappers.EntityFramework.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-	<Version>8.0.0-preview.1</Version>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+	<Version>8.0.0-preview.2</Version>
     <Authors>Leonardo Porro</Authors>
     <Company />
     <Product>Detached</Product>

--- a/src/Detached.Mappers.HotChocolate/Detached.Mappers.HotChocolate.csproj
+++ b/src/Detached.Mappers.HotChocolate/Detached.Mappers.HotChocolate.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-	<Version>8.0.0-preview.1</Version>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+	<Version>8.0.0-preview.2</Version>
     <Authors>Leonardo Porro</Authors>
     <Company />
     <Product>Detached</Product>

--- a/src/Detached.Mappers.Json/Detached.Mappers.Json.csproj
+++ b/src/Detached.Mappers.Json/Detached.Mappers.Json.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<Version>8.0.0-preview.1</Version>
+		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<Version>8.0.0-preview.2</Version>
 		<Authors>Leonardo Porro</Authors>
 		<Company />
 		<Product>Detached</Product>

--- a/src/Detached.Mappers/Detached.Mappers.csproj
+++ b/src/Detached.Mappers/Detached.Mappers.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-	<Version>8.0.0-preview.1</Version>
+	<Version>8.0.0-preview.2</Version>
     <Authors>Leonardo Porro</Authors>
     <Company />
     <Product>Detached</Product>


### PR DESCRIPTION
Entity Framework Core currently supports .Net 6, 7 and 8. 
I don't think we have to limit the usage of this library to only .Net 8 for now. 
This may change in the future when they get closer to the release of EF8 as explained [here](https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-8.0/plan#supported-platforms)

Further implements #94 